### PR TITLE
WP_Widget is deprecated from version 4.3.0, use __construct()

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -4,7 +4,7 @@ class fep_widget extends WP_Widget
     public function fep_widget()
     {
         $widget_ops = ['classname' => 'fep_login', 'description' => __('Display login widget on sidebar ', 'fep')];
-        $this->WP_Widget('fep_widget', 'Frontend Login', $widget_ops);
+        $this->__construct('fep_widget', 'Frontend Login', $widget_ops);
     }
 
     public function form($instance)


### PR DESCRIPTION
Use new standard, avoid deprecated initilialization. Here more infos
https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/
